### PR TITLE
Read Among Us memory to enable automatic muting

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   fmt:
     name: Format
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
 
     steps:
       - name: Checkout
@@ -21,14 +21,14 @@ jobs:
           components: rustfmt
           profile: minimal
           override: true
-      
+
       - name: rustfmt
         run: cargo fmt --all -- --check
-  
+
   clippy:
     name: Clippy
     needs: [fmt]
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
 
     steps:
       - name: Checkout
@@ -75,98 +75,48 @@ jobs:
           release_name: Release ${{ github.sha }}
           draft: true
           prerelease: false
-  
+
   build:
-    name: Build for ${{ matrix.os }}
-    needs: [fmt, clippy, release]
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macos-latest]
-    
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-
-          
-    - name: Install toolchain
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-        profile: minimal
-        override: true
-
-    - name: Setup cache
-      uses: actions/cache@v2
-      with:
-        path: |
-          ~/.cargo/registry
-          ~/.cargo/git
-          target
-        key: ${{ runner.os }}-rustc-${{ steps.toolchain.outputs.rustc_hash }}-${{ hashFiles('**/Cargo.lock') }}
-        
-    - name: Build
-      uses: actions-rs/cargo@v1
-      with:
-        command: build
-        args: --release
-    
-    - name: Zip
-      run: |
-        mv ${{ github.workspace }}/target/release/taskinator ${{ github.workspace }}/taskinator-${{ runner.os }}
-
-    - name: Upload Release Asset
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ needs.release.outputs.upload_url }}
-        asset_path: ${{ github.workspace }}/taskinator-${{ runner.os }}
-        asset_name: taskinator-${{ runner.os }}
-        asset_content_type: application/octet-stream
-
-  build_win:
-    name: Build for windows-latest
+    name: Build for Windows
     needs: [fmt, clippy, release]
     runs-on: windows-latest
-    
+
     steps:
-    - name: Checkout
-      uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v2
 
-          
-    - name: Install toolchain
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-        profile: minimal
-        override: true
+      - name: Install toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
 
-    - name: Setup cache
-      uses: actions/cache@v2
-      with:
-        path: |
-          ~/.cargo/registry
-          ~/.cargo/git
-          target
-        key: ${{ runner.os }}-rustc-${{ steps.toolchain.outputs.rustc_hash }}-${{ hashFiles('**/Cargo.lock') }}
-        
-    - name: Build
-      uses: actions-rs/cargo@v1
-      with:
-        command: build
-        args: --release
-    
-    - name: Zip
-      run: |
-        mv ${{ github.workspace }}/target/release/taskinator.exe ${{ github.workspace }}/taskinator-${{ runner.os }}.exe
+      - name: Setup cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-rustc-${{ steps.toolchain.outputs.rustc_hash }}-${{ hashFiles('**/Cargo.lock') }}
 
-    - name: Upload Release Asset
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ needs.release.outputs.upload_url }}
-        asset_path: ${{ github.workspace }}/taskinator-${{ runner.os }}.exe
-        asset_name: taskinator-${{ runner.os }}.exe
-        asset_content_type: application/octet-stream
+      - name: Build
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --release
+
+      - name: Move
+        run: |
+          mv ${{ github.workspace }}/target/release/taskinator.exe ${{ github.workspace }}/taskinator.exe
+
+      - name: Upload Release Asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ needs.release.outputs.upload_url }}
+          asset_path: ${{ github.workspace }}/taskinator.exe
+          asset_name: taskinator.exe
+          asset_content_type: application/octet-stream

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
+/.cargo
 
 Config.toml

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -515,9 +515,9 @@ dependencies = [
 
 [[package]]
 name = "idna"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de910d521f7cc3135c4de8db1cb910e0b5ed1dc6f57c381cd07e8e661ce10094"
+checksum = "89829a5d69c23d348314a7ac337fe39173b61149a9864deabd260983aed48c21"
 dependencies = [
  "matches",
  "unicode-bidi",
@@ -1255,6 +1255,7 @@ dependencies = [
 [[package]]
 name = "taskinator-communicator"
 version = "0.1.0"
+source = "git+https://github.com/sam-kirby/taskinator-communicator.git?branch=main#152594a2ddb5a2f598364431497cad98dba00287"
 dependencies = [
  "tracing",
  "windows",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,27 +16,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-stream"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3670df70cbc01729f901f94c887814b3c68db038aad1329a418bae178bc5295c"
-dependencies = [
- "async-stream-impl",
- "futures-core",
-]
-
-[[package]]
-name = "async-stream-impl"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3548b8efc9f8e8a5a0a2808c5bd8451a9031b9e5b879a79590304ae928b0a70"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "async-tungstenite"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -45,7 +24,7 @@ dependencies = [
  "futures-io",
  "futures-util",
  "log",
- "pin-project 1.0.4",
+ "pin-project",
  "tokio",
  "tokio-rustls",
  "tungstenite",
@@ -87,9 +66,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.5.0"
+version = "3.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f07aa6688c702439a1be0307b6a94dffe1168569e45b9500c1372bc580740d59"
+checksum = "099e596ef14349721d9016f6b80dd3419ea1bf289ab9b44df8e4dfd3a005d5d9"
 
 [[package]]
 name = "byteorder"
@@ -135,6 +114,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-sha1"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb58b6451e8c2a812ad979ed1d83378caa5e927eef2622017a45f251457c2c9d"
+
+[[package]]
+name = "const_fn"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28b9d6de7f49e22cf97ad17fc4036ece69300032f45f78f30b4a4482cdc3f4a6"
+
+[[package]]
 name = "core-foundation"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -166,6 +157,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dca26ee1f8d361640700bde38b2c37d8c22b3ce2d360e1fc1c74ea4b0aa7d775"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94af6efb46fef72616855b036a624cf27ba656ffc9be1b9a3c931cfc7749a9a9"
+dependencies = [
+ "cfg-if",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1aaa739f95311c2c7887a76863f500026092fb1dce0161dab577e559ef3569d"
+dependencies = [
+ "cfg-if",
+ "const_fn",
+ "crossbeam-utils",
+ "lazy_static",
+ "memoffset",
+ "scopeguard",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02d96d1e189ef58269ebe5b97953da3274d83a93af647c2ddd6f9dab28cedb8d"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "lazy_static",
+]
+
+[[package]]
 name = "ct-logs"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -194,10 +231,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "flate2"
-version = "1.0.19"
+name = "doc-comment"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7411863d55df97a419aa64cb4d2f167103ea9d767e2c54a1868b7ac3f6b47129"
+checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
+
+[[package]]
+name = "either"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
+
+[[package]]
+name = "flate2"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd3aec53de10fe96d7d8c565eb17f2c687bb5518a2ec453b5b1252964526abe0"
 dependencies = [
  "cfg-if",
  "crc32fast",
@@ -352,7 +401,7 @@ checksum = "c9495705279e7140bf035dde1f6e750c162df8b625267cd52cc44e0b156732c8"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.10.1+wasi-snapshot-preview1",
+ "wasi 0.10.2+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -413,9 +462,9 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.3.4"
+version = "1.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd179ae861f0c2e53da70d892f5f3029f9594be0c41dc5269cd371691b1dc2f9"
+checksum = "615caabe2c3160b313d52ccc905335f4ed5f10881dd63dc5699d47e90be85691"
 
 [[package]]
 name = "httpdate"
@@ -425,9 +474,9 @@ checksum = "494b4d60369511e7dea41cf646832512a94e542f68bb9c49e54518e0f468eb47"
 
 [[package]]
 name = "hyper"
-version = "0.14.2"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12219dc884514cb4a6a03737f4413c0e01c23a1b059b0156004b23f1e19dccbe"
+checksum = "e8e946c2b1349055e0b72ae281b238baf1a3ea7307c7e9f9d64673bdd9c26ac7"
 dependencies = [
  "bytes 1.0.1",
  "futures-channel",
@@ -439,7 +488,7 @@ dependencies = [
  "httparse",
  "httpdate",
  "itoa",
- "pin-project 1.0.4",
+ "pin-project",
  "socket2",
  "tokio",
  "tower-service",
@@ -466,9 +515,9 @@ dependencies = [
 
 [[package]]
 name = "idna"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02e2673c30ee86b5b96a9cb52ad15718aa1f966f5ab9ad54a8b95d5ca33120a9"
+checksum = "de910d521f7cc3135c4de8db1cb910e0b5ed1dc6f57c381cd07e8e661ce10094"
 dependencies = [
  "matches",
  "unicode-bidi",
@@ -526,9 +575,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.82"
+version = "0.2.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89203f3fba0a3795506acaad8ebce3c80c0af93f994d5a1d7a0b1eeb23271929"
+checksum = "b7282d924be3275cec7f6756ff4121987bc6481325397dde6ba3e7802b1a8b1c"
 
 [[package]]
 name = "libz-sys"
@@ -581,6 +630,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
 
 [[package]]
+name = "memoffset"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "157b4208e3059a8f9e78d559edc658e13df41410cb3ae03979c83130067fdd87"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "miniz_oxide"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -592,9 +650,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.7.7"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e50ae3f04d169fcc9bde0b547d1c205219b7157e07ded9c5aff03e0637cb3ed7"
+checksum = "dc250d6848c90d719ea2ce34546fb5df7af1d3fd189d10bf7bad80bfcebecd95"
 dependencies = [
  "libc",
  "log",
@@ -671,9 +729,9 @@ checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
 
 [[package]]
 name = "ordered-float"
-version = "2.0.1"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dacdec97876ef3ede8c50efc429220641a0b11ba0048b4b0c357bccbc47c5204"
+checksum = "766f840da25490628d8e63e529cd21c014f6600c6b8517add12a6fa6167a6218"
 dependencies = [
  "num-traits",
 ]
@@ -691,9 +749,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ccb628cad4f84851442432c60ad8e1f607e29752d0bf072cbd0baf28aa34272"
+checksum = "fa7a782938e745763fe6907fc6ba86946d72f49fe7e21de074e08128a99fb018"
 dependencies = [
  "cfg-if",
  "instant",
@@ -711,38 +769,18 @@ checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
 name = "pin-project"
-version = "0.4.27"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ffbc8e94b38ea3d2d8ba92aea2983b503cd75d0888d75b86bb37970b5698e15"
+checksum = "96fa8ebb90271c4477f144354485b8068bd8f6b78b428b01ba892ca26caf0b63"
 dependencies = [
- "pin-project-internal 0.4.27",
-]
-
-[[package]]
-name = "pin-project"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95b70b68509f17aa2857863b6fa00bf21fc93674c7a8893de2f469f6aa7ca2f2"
-dependencies = [
- "pin-project-internal 1.0.4",
+ "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "0.4.27"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65ad2ae56b6abe3a1ee25f15ee605bacadb9a764edaba9c2bf4103800d4a1895"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "pin-project-internal"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caa25a6393f22ce819b0f50e0be89287292fda8d425be38ee0ca14c4931d9e71"
+checksum = "758669ae3558c6f74bd2a18b41f7ac0b5a195aea6639d6a9b5e5d1ad5ba24c0b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -796,9 +834,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.8"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "991431c3519a3f36861882da93630ce66b52918dcf1b8e2fd66b397fc96f28df"
+checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
 dependencies = [
  "proc-macro2",
 ]
@@ -824,7 +862,7 @@ checksum = "0ef9e7e66b4468674bfcb0c81af8b7fa0bb154fa9f28eb840da5c447baeb8d7e"
 dependencies = [
  "libc",
  "rand_chacha 0.3.0",
- "rand_core 0.6.1",
+ "rand_core 0.6.2",
  "rand_hc 0.3.0",
 ]
 
@@ -845,7 +883,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e12735cf05c9e10bf21534da50a147b924d555dc7a547c42e6bb2d5b6017ae0d"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.6.1",
+ "rand_core 0.6.2",
 ]
 
 [[package]]
@@ -859,9 +897,9 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c026d7df8b298d90ccbbc5190bd04d85e159eaf5576caeacf8741da93ccbd2e5"
+checksum = "34cf66eb183df1c5876e2dcf6b13d57340741e8dc255b48e40a26de954d06ae7"
 dependencies = [
  "getrandom 0.2.2",
 ]
@@ -881,14 +919,42 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3190ef7066a446f2e7f42e239d161e905420ccab01eb967c9eb27d21b2322a73"
 dependencies = [
- "rand_core 0.6.1",
+ "rand_core 0.6.2",
+]
+
+[[package]]
+name = "rayon"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b0d8e0819fadc20c74ea8373106ead0600e3a67ef1fe8da56e39b9ae7275674"
+dependencies = [
+ "autocfg",
+ "crossbeam-deque",
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ab346ac5921dc62ffa9f89b7a773907511cdfa5490c572ae9be1be33e8afa4a"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-utils",
+ "lazy_static",
+ "num_cpus",
 ]
 
 [[package]]
 name = "redox_syscall"
-version = "0.1.57"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
+checksum = "94341e4e44e24f6b591b59e47a8a027df12e008d73fd5672dbea9cc22f4507d9"
+dependencies = [
+ "bitflags",
+]
 
 [[package]]
 name = "regex"
@@ -917,9 +983,9 @@ checksum = "b5eb417147ba9860a96cfe72a0b93bf88fee1744b5636ec99ab20c1aa9376581"
 
 [[package]]
 name = "ring"
-version = "0.16.19"
+version = "0.16.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "024a1e66fea74c66c66624ee5622a7ff0e4b73a13b4f5c326ddb50c708944226"
+checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
 dependencies = [
  "cc",
  "libc",
@@ -1042,9 +1108,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.61"
+version = "1.0.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fceb2595057b6891a4ee808f70054bd2d12f0e97f1cbb78689b59f676df325a"
+checksum = "ea1c6153794552ea7cf7cf63b1231a25de00ec90db326ba6264440fa08e31486"
 dependencies = [
  "itoa",
  "ryu",
@@ -1064,9 +1130,9 @@ dependencies = [
 
 [[package]]
 name = "sha-1"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce3cdf1b5e620a498ee6f2a171885ac7e22f0e12089ec4b3d22b84921792507c"
+checksum = "dfebf75d25bd900fd1e7d11501efab59bc846dbc76196839663e6637bba9f25f"
 dependencies = [
  "block-buffer",
  "cfg-if",
@@ -1074,6 +1140,12 @@ dependencies = [
  "digest",
  "opaque-debug",
 ]
+
+[[package]]
+name = "sha1"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2579985fda508104f7587689507983eadd6a6e84dd35d6d115361f530916fa0d"
 
 [[package]]
 name = "sharded-slab"
@@ -1123,6 +1195,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
+name = "squote"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fccf17fd09e2455ea796d2ad267b64fa2c5cbd8701b2a93b555d2aa73449f7d"
+
+[[package]]
 name = "syn"
 version = "1.0.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1134,12 +1212,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "sysinfo"
+version = "0.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d39c47be321239a7b3d232d733e58b257c6727167e61ee18c87cd2fa2b5b1b"
+dependencies = [
+ "cfg-if",
+ "core-foundation-sys",
+ "doc-comment",
+ "libc",
+ "ntapi",
+ "once_cell",
+ "rayon",
+ "winapi",
+]
+
+[[package]]
 name = "taskinator"
-version = "0.2.2"
+version = "0.3.0-alpha"
 dependencies = [
  "futures",
  "parking_lot",
  "serde",
+ "sysinfo",
+ "taskinator-communicator",
  "tokio",
  "tokio-stream",
  "toml",
@@ -1157,10 +1253,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "taskinator-communicator"
+version = "0.1.0"
+dependencies = [
+ "tracing",
+ "windows",
+]
+
+[[package]]
 name = "thread_local"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8208a331e1cb318dd5bd76951d2b8fc48ca38a69f5f4e4af1b6a9f8c6236915"
+checksum = "8018d24e04c95ac8790716a5987d0fec4f8b27249ffa0f7d33f1369bdfb88cbd"
 dependencies = [
  "once_cell",
 ]
@@ -1192,9 +1296,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8efab2086f17abcddb8f756117665c958feee6b2e39974c2f1600592ab3a4195"
+checksum = "e8190d04c665ea9e6b6a0dc45523ade572c088d2e6566244c1122671dbf4ae3a"
 dependencies = [
  "autocfg",
  "bytes 1.0.1",
@@ -1205,7 +1309,19 @@ dependencies = [
  "once_cell",
  "pin-project-lite",
  "signal-hook-registry",
+ "tokio-macros",
  "winapi",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caf7b11a536f46a809a8a9f0bb4237020f70ecbf115b842360afb127ea2fda57"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1221,9 +1337,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76066865172052eb8796c686f0b441a93df8b08d40a950b062ffb9a426f00edd"
+checksum = "1981ad97df782ab506a1f43bf82c967326960d278acf3bf8279809648c3ff3ea"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -1232,18 +1348,16 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "feb971a26599ffd28066d387f109746df178eff14d5ea1e235015c5601967a4b"
+checksum = "ebb7cb2f00c5ae8df755b252306272cd1790d39728363936e01827e11f0b017b"
 dependencies = [
- "async-stream",
  "bytes 1.0.1",
  "futures-core",
  "futures-sink",
  "log",
  "pin-project-lite",
  "tokio",
- "tokio-stream",
 ]
 
 [[package]]
@@ -1263,9 +1377,9 @@ checksum = "360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6"
 
 [[package]]
 name = "tracing"
-version = "0.1.22"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f47026cdc4080c07e49b37087de021820269d996f581aac150ef9e5583eefe3"
+checksum = "f77d3842f76ca899ff2dbcf231c5c65813dea431301d6eb686279c15c4464f12"
 dependencies = [
  "cfg-if",
  "pin-project-lite",
@@ -1275,9 +1389,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.11"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80e0ccfc3378da0cce270c946b676a376943f5cd16aeba64568e7939806f4ada"
+checksum = "a8a9bd1db7706f2373a190b0d067146caa39350c486f3d455b0e33b431f94c07"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1295,11 +1409,11 @@ dependencies = [
 
 [[package]]
 name = "tracing-futures"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab7bb6f14721aa00656086e9335d363c5c8747bae02ebe32ea2c7dece5689b4c"
+checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
 dependencies = [
- "pin-project 0.4.27",
+ "pin-project",
  "tracing",
 ]
 
@@ -1527,9 +1641,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a13e63ab62dbe32aeee58d1c5408d35c36c392bba5d9d3142287219721afe606"
+checksum = "07fbfce1c8a97d547e8b5334978438d9d6ec8c20e38f56d4a4374d181493eaef"
 dependencies = [
  "tinyvec",
 ]
@@ -1594,9 +1708,9 @@ checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"
-version = "0.10.1+wasi-snapshot-preview1"
+version = "0.10.2+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93c6c3420963c5c64bca373b25e77acb562081b9bb4dd5bb864187742186cea9"
+checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "wasm-bindgen"
@@ -1702,3 +1816,79 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8577253c781c3aa634017840854139a65a51de658fb61577e5c91e995ebdd18e"
+dependencies = [
+ "const-sha1",
+ "windows_gen",
+ "windows_macros",
+ "windows_winmd",
+]
+
+[[package]]
+name = "windows_gen"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de23e2765bf82678467efef4ccdeb150a2456b2b01688fbd7c86292c1c931ee7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rayon",
+ "sha1",
+ "squote",
+ "syn",
+ "windows_gen_macros",
+ "windows_winmd",
+]
+
+[[package]]
+name = "windows_gen_macros"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "878ecff0c53decca3851547869b5473081198cfe97405b14412be9283a05ae34"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows_macros"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aaedcc12658411370a43f9c194c40ed4bae0047c39e48ebf67e92d241a97f0c7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rayon",
+ "squote",
+ "syn",
+ "windows_gen",
+ "windows_winmd",
+]
+
+[[package]]
+name = "windows_winmd"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40a0769bcad04692eb69e92ff93ce49c89ca5aeda188e98f5cc9b8502b41d6c0"
+dependencies = [
+ "serde",
+ "serde_json",
+ "windows_winmd_macros",
+]
+
+[[package]]
+name = "windows_winmd_macros"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f67ec9020d1bbfeaa8847ababe33b8dc190d683624cd72a48a4a117de50d6559"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,9 +72,9 @@ checksum = "63396b8a4b9de3f4fdfb320ab6080762242f66a8ef174c49d8e19b674db4cdbe"
 
 [[package]]
 name = "byteorder"
-version = "1.4.2"
+version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae44d1a3d5a19df61dd0c8beb138458ac2a53a7ac09eba97d55592540004306b"
+checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
@@ -151,9 +151,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dca26ee1f8d361640700bde38b2c37d8c22b3ce2d360e1fc1c74ea4b0aa7d775"
+checksum = "06ed27e177f16d65f0f0c22a213e17c696ace5dd64b14258b52f9417ccb52db4"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -265,9 +265,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f55667319111d593ba876406af7c409c0ebb44dc4be6132a783ccf163ea14c1"
+checksum = "a9d5813545e459ad3ca1bff9915e9ad7f1a47dc6a91b627ce321d5863b7dd253"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -280,9 +280,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c2dd2df839b57db9ab69c2c9d8f3e8c81984781937fe2807dc6dcf3b2ad2939"
+checksum = "ce79c6a52a299137a6013061e0cf0e688fce5d7f1bc60125f520912fdb29ec25"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -290,15 +290,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15496a72fabf0e62bdc3df11a59a3787429221dd0710ba8ef163d6f7a9112c94"
+checksum = "098cd1c6dda6ca01650f1a37a794245eb73181d0d4d4e955e2f3c37db7af1815"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891a4b7b96d84d5940084b2a37632dd65deeae662c114ceaa2c879629c9c0ad1"
+checksum = "10f6cb7042eda00f0049b1d2080aa4b93442997ee507eb3828e8bd7577f94c9d"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -307,15 +307,15 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71c2c65c57704c32f5241c1223167c2c3294fd34ac020c807ddbe6db287ba59"
+checksum = "365a1a1fb30ea1c03a830fdb2158f5236833ac81fa0ad12fe35b29cddc35cb04"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea405816a5139fb39af82c2beb921d52143f556038378d6db21183a5c37fbfb7"
+checksum = "668c6733a182cd7deb4f1de7ba3bf2120823835b3bcfbeacf7d2c4a773c1bb8b"
 dependencies = [
  "proc-macro-hack",
  "proc-macro2",
@@ -325,15 +325,15 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85754d98985841b7d4f5e8e6fbfa4a4ac847916893ec511a2917ccd8525b8bb3"
+checksum = "5c5629433c555de3d82861a7a4e3794a4c40040390907cfbfd7143a92a426c23"
 
 [[package]]
 name = "futures-task"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa189ef211c15ee602667a6fcfe1c1fd9e07d42250d2156382820fba33c9df80"
+checksum = "ba7aa51095076f3ba6d9a1f702f74bd05ec65f555d70d2033d55ba8d69f581bc"
 
 [[package]]
 name = "futures-timer"
@@ -343,9 +343,9 @@ checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
 
 [[package]]
 name = "futures-util"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1812c7ab8aedf8d6f2701a43e1243acdbcc2b36ab26e2ad421eb99ac963d96d1"
+checksum = "3c144ad54d60f23927f0a6b6d816e4271278b64f005ad65e4e35291d2de9c025"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -395,9 +395,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d832b01df74254fe364568d6ddc294443f61cbec82816b60904303af87efae78"
+checksum = "fc018e188373e2777d0ef2467ebff62a08e66c3f5857b23c8fbec3018210dc00"
 dependencies = [
  "bytes 1.0.1",
  "fnv",
@@ -429,9 +429,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7245cd7449cc792608c3c8a9eaf69bd4eabbabf802713748fd739c98b82f0747"
+checksum = "527e8c9ac747e28542699a951517aa9a6945af506cd1f2e1b53a576c17b6cc11"
 dependencies = [
  "bytes 1.0.1",
  "fnv",
@@ -440,19 +440,20 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2861bd27ee074e5ee891e8b539837a9430012e249d7f0ca2d795650f579c1994"
+checksum = "5dfb77c123b4e2f72a2069aeae0b4b4949cc7e966df277813fc16347e7549737"
 dependencies = [
  "bytes 1.0.1",
  "http",
+ "pin-project-lite",
 ]
 
 [[package]]
 name = "httparse"
-version = "1.3.5"
+version = "1.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "615caabe2c3160b313d52ccc905335f4ed5f10881dd63dc5699d47e90be85691"
+checksum = "bc35c995b9d93ec174cf9a27d425c7892722101e14993cd227fdb51d70cf9589"
 
 [[package]]
 name = "httpdate"
@@ -462,9 +463,9 @@ checksum = "494b4d60369511e7dea41cf646832512a94e542f68bb9c49e54518e0f468eb47"
 
 [[package]]
 name = "hyper"
-version = "0.14.4"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8e946c2b1349055e0b72ae281b238baf1a3ea7307c7e9f9d64673bdd9c26ac7"
+checksum = "8bf09f61b52cfcf4c00de50df88ae423d6c02354e385a86341133b5338630ad1"
 dependencies = [
  "bytes 1.0.1",
  "futures-channel",
@@ -548,9 +549,9 @@ checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
 
 [[package]]
 name = "js-sys"
-version = "0.3.48"
+version = "0.3.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc9f84f9b115ce7843d60706df1422a916680bfdfcbdb0447c5614ff9d7e4d78"
+checksum = "2d99f9e3e84b8f67f846ef5b4cbbc3b1c29f6c759fcbce6f01aa0e73d932a24c"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -563,9 +564,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.88"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03b07a082330a35e43f63177cc01689da34fbffa0105e1246cf0311472cac73a"
+checksum = "9385f66bf6105b241aa65a61cb923ef20efc665cb9f9bb50ac2f0c4b7f378d41"
 
 [[package]]
 name = "libz-sys"
@@ -580,9 +581,9 @@ dependencies = [
 
 [[package]]
 name = "lock_api"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd96ffd135b2fd7b973ac026d28085defbe8983df057ced3eb4f2130b0831312"
+checksum = "5a3c91c24eae6777794bb1997ad98bbb87daf92890acab859f7eaa4320333176"
 dependencies = [
  "scopeguard",
 ]
@@ -619,9 +620,9 @@ checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
 
 [[package]]
 name = "memoffset"
-version = "0.6.1"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "157b4208e3059a8f9e78d559edc658e13df41410cb3ae03979c83130067fdd87"
+checksum = "f83fb6581e8ed1f85fd45c116db8405483899489e38406156c25eb743554361d"
 dependencies = [
  "autocfg",
 ]
@@ -638,9 +639,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.7.9"
+version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5dede4e2065b3842b8b0af444119f3aa331cc7cc2dd20388bfb0f5d5a38823a"
+checksum = "cf80d3e903b34e0bd7282b218398aec54e082c840d9baf8339e0080a0c542956"
 dependencies = [
  "libc",
  "log",
@@ -651,11 +652,10 @@ dependencies = [
 
 [[package]]
 name = "miow"
-version = "0.3.6"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a33c1b55807fbed163481b5ba66db4b2fa6cde694a5027be10fb724206c5897"
+checksum = "b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21"
 dependencies = [
- "socket2",
  "winapi",
 ]
 
@@ -757,18 +757,18 @@ checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
 name = "pin-project"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96fa8ebb90271c4477f144354485b8068bd8f6b78b428b01ba892ca26caf0b63"
+checksum = "bc174859768806e91ae575187ada95c91a29e96a98dc5d2cd9a1fed039501ba6"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758669ae3558c6f74bd2a18b41f7ac0b5a195aea6639d6a9b5e5d1ad5ba24c0b"
+checksum = "a490329918e856ed1b083f244e3bfe2d8c4f336407e4ea9e1a9f479ff09049e5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -813,9 +813,9 @@ checksum = "bc881b2c22681370c6a780e47af9840ef841837bc98118431d4e1868bd0c1086"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.24"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e0704ee1a7e00d7bb417d0770ea303c1bccbabf0ef1667dae92b5967f5f8a71"
+checksum = "a152013215dca273577e18d2bf00fa862b89b24169fb78c4c95aeb07992c9cec"
 dependencies = [
  "unicode-xid",
 ]
@@ -946,9 +946,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.4.3"
+version = "1.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9251239e129e16308e70d853559389de218ac275b515068abc96829d05b948a"
+checksum = "957056ecddbeba1b26965114e191d2e8589ce74db242b6ea25fc4062427a5c19"
 dependencies = [
  "regex-syntax",
 ]
@@ -965,9 +965,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.22"
+version = "0.6.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5eb417147ba9860a96cfe72a0b93bf88fee1744b5636ec99ab20c1aa9376581"
+checksum = "24d5f089152e60f62d28b835fbff2cd2e8dc0baf1ac13343bef92ab7eed84548"
 
 [[package]]
 name = "ring"
@@ -1033,9 +1033,9 @@ checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
 name = "sct"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3042af939fca8c3453b7af0f1c66e533a15a86169e39de2657310ade8f98d3c"
+checksum = "b362b83898e0e69f38515b82ee15aa80636befe47c3b6d3d89a911e78fc228ce"
 dependencies = [
  "ring",
  "untrusted",
@@ -1043,9 +1043,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dfd318104249865096c8da1dfabf09ddbb6d0330ea176812a62ec75e40c4166"
+checksum = "3670b1d2fdf6084d192bc71ead7aabe6c06aa2ea3fbd9cc3ac111fa5c2b1bd84"
 dependencies = [
  "bitflags",
  "core-foundation",
@@ -1056,9 +1056,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dee48cdde5ed250b0d3252818f646e174ab414036edb884dde62d80a3ac6082d"
+checksum = "3676258fd3cfe2c9a0ec99ce3038798d847ce3e4bb17746373eb9f0f1ac16339"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -1066,9 +1066,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.124"
+version = "1.0.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd761ff957cb2a45fbb9ab3da6512de9de55872866160b23c25f1a841e99d29f"
+checksum = "558dc50e1a5a5fa7112ca2ce4effcb321b0300c0d4ccf0776a9f60cd89031171"
 dependencies = [
  "serde_derive",
 ]
@@ -1085,9 +1085,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.124"
+version = "1.0.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1800f7693e94e186f5e25a28291ae1570da908aff7d97a095dec1e56ff99069b"
+checksum = "b093b7a2bb58203b5da3056c05b4ec1fed827dcfdb37347a8841695263b3d06d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1167,11 +1167,10 @@ checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
 
 [[package]]
 name = "socket2"
-version = "0.3.19"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "122e570113d28d773067fab24266b66753f6ea915758651696b6e35e49f88d6e"
+checksum = "9e3dfc207c526015c632472a77be09cf1b6e46866581aecae5cc38fb4235dea2"
 dependencies = [
- "cfg-if",
  "libc",
  "winapi",
 ]
@@ -1190,9 +1189,9 @@ checksum = "1fccf17fd09e2455ea796d2ad267b64fa2c5cbd8701b2a93b555d2aa73449f7d"
 
 [[package]]
 name = "syn"
-version = "1.0.61"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed22b90a0e734a23a7610f4283ac9e5acfb96cbb30dfefa540d66f866f1c09c5"
+checksum = "48fe99c6bd8b1cc636890bcc071842de909d902c81ac7dab53ba33c421ab8ffb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1201,9 +1200,9 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.16.4"
+version = "0.16.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c280c91abd1aed2e36be1bc8f56fbc7a2acbb2b58fbcac9641510179cc72dd9"
+checksum = "567e910ef0207be81a4e1bb0491e9a8d9866cf45b20fe1a52c03d347da9ea51b"
 dependencies = [
  "cfg-if",
  "core-foundation-sys",
@@ -1242,8 +1241,8 @@ dependencies = [
 
 [[package]]
 name = "taskinator-communicator"
-version = "0.1.1"
-source = "git+https://github.com/sam-kirby/taskinator-communicator.git?branch=main#f005288e04eba1f0036baf270b7cb458664d5761"
+version = "0.1.4"
+source = "git+https://github.com/sam-kirby/taskinator-communicator.git?branch=main#1dd9412934a70bf9913343ba67652d10be205a1f"
 dependencies = [
  "tracing",
  "windows",
@@ -1260,9 +1259,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "317cca572a0e89c3ce0ca1f1bdc9369547fe318a683418e42ac8f59d14701023"
+checksum = "5b5220f05bb7de7f3f53c7c065e1199b3172696fe2db9f9c4d8ad9b4ee74c342"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -1275,9 +1274,9 @@ checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "tokio"
-version = "1.2.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8190d04c665ea9e6b6a0dc45523ade572c088d2e6566244c1122671dbf4ae3a"
+checksum = "83f0c8e7c0addab50b663055baf787d0af7f413a46e6e7fb9559a4e4db7137a5"
 dependencies = [
  "autocfg",
  "bytes 1.0.1",
@@ -1316,9 +1315,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.3"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1981ad97df782ab506a1f43bf82c967326960d278acf3bf8279809648c3ff3ea"
+checksum = "e177a5d8c3bf36de9ebe6d58537d8879e964332f93fb3339e43f618c81361af0"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -1327,9 +1326,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.6.3"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebb7cb2f00c5ae8df755b252306272cd1790d39728363936e01827e11f0b017b"
+checksum = "940a12c99365c31ea8dd9ba04ec1be183ffe4920102bb7122c2f515437601e8e"
 dependencies = [
  "bytes 1.0.1",
  "futures-core",
@@ -1368,9 +1367,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.13"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8a9bd1db7706f2373a190b0d067146caa39350c486f3d455b0e33b431f94c07"
+checksum = "c42e6fa53307c8a17e4ccd4dc81cf5ec38db9209f59b222210375b54ee40d1e2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1409,9 +1408,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ab8966ac3ca27126141f7999361cc97dd6fb4b71da04c02044fa9045d98bb96"
+checksum = "705096c6f83bf68ea5d357a6aa01829ddbdac531b357b45abeca842938085baa"
 dependencies = [
  "ansi_term",
  "chrono",
@@ -1456,9 +1455,9 @@ dependencies = [
 
 [[package]]
 name = "twilight-cache-inmemory"
-version = "0.3.1"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1027eae7a3edda6809f18c67395891fd1763495c3e43c4aed4ff0b8076267caa"
+checksum = "b927590e62b33e897e6dd033b9df8f6c85cc04c77b3d29965af88542eab63526"
 dependencies = [
  "bitflags",
  "dashmap",
@@ -1487,9 +1486,9 @@ dependencies = [
 
 [[package]]
 name = "twilight-gateway"
-version = "0.3.2"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4da194f38883a397f77ffb3053dc544e1e2e980da298982b3ff140b310b15fe9"
+checksum = "2f6395849e0e6f96f79b0602d9c12eebe9523931b4ccc8d1d9202d9b1e18eebe"
 dependencies = [
  "async-tungstenite",
  "bitflags",
@@ -1524,9 +1523,9 @@ dependencies = [
 
 [[package]]
 name = "twilight-http"
-version = "0.3.4"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d87434e426d8d99e8493a7b620ccfd857be958288e265b8a560bfe91ffdbf2f"
+checksum = "ccd5abf3edca789b90170bef8c09dafb9276cda3889507ebe1a5cf795dbfa805"
 dependencies = [
  "bytes 1.0.1",
  "futures-channel",
@@ -1554,9 +1553,9 @@ dependencies = [
 
 [[package]]
 name = "twilight-model"
-version = "0.3.2"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab3a477a8cf11965d5d69895351eec141fad4dfa04d9ac3113237c9ccf66e35d"
+checksum = "dea0bac438b70fe8adbc9bf0b53b8a6ba2711e9982432dffbc83b46e38d2f200"
 dependencies = [
  "bitflags",
  "serde",
@@ -1586,9 +1585,9 @@ checksum = "20e775515758ca610392c45452670e3e0e4affad9f4a137182604ba0f5645b4f"
 
 [[package]]
 name = "typenum"
-version = "1.12.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "373c8a200f9e67a0c95e62a4f52fbf80c23b4381c05a17845531982fa99e6b33"
+checksum = "879f6906492a7cd215bfa4cf595b600146ccfac0c79bcbd1f3000162af5e8b06"
 
 [[package]]
 name = "unicase"
@@ -1601,9 +1600,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49f2bd0c6468a8230e1db229cff8029217cf623c767ea5d60bfbd42729ea54d5"
+checksum = "eeb8be209bb1c96b7c177c7420d26e04eccacb0eeae6b980e35fcb74678107e0"
 dependencies = [
  "matches",
 ]
@@ -1655,9 +1654,9 @@ checksum = "b00bca6106a5e23f3eee943593759b7fcddb00554332e856d990c893966879fb"
 
 [[package]]
 name = "version_check"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"
+checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
 
 [[package]]
 name = "want"
@@ -1683,9 +1682,9 @@ checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.71"
+version = "0.2.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ee1280240b7c461d6a0071313e08f34a60b0365f14260362e5a2b17d1d31aa7"
+checksum = "83240549659d187488f91f33c0f8547cbfef0b2088bc470c116d1d260ef623d9"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -1693,9 +1692,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.71"
+version = "0.2.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b7d8b6942b8bb3a9b0e73fc79b98095a27de6fa247615e59d096754a3bc2aa8"
+checksum = "ae70622411ca953215ca6d06d3ebeb1e915f0f6613e3b495122878d7ebec7dae"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -1708,9 +1707,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.71"
+version = "0.2.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5ac38da8ef716661f0f36c0d8320b89028efe10c7c0afde65baffb496ce0d3b"
+checksum = "3e734d91443f177bfdb41969de821e15c516931c3c3db3d318fa1b68975d0f6f"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1718,9 +1717,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.71"
+version = "0.2.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc053ec74d454df287b9374ee8abb36ffd5acb95ba87da3ba5b7d3fe20eb401e"
+checksum = "d53739ff08c8a68b0fdbcd54c372b8ab800b1449ab3c9d706503bc7dd1621b2c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1731,15 +1730,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.71"
+version = "0.2.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d6f8ec44822dd71f5f221a5847fb34acd9060535c1211b70a05844c0f6383b1"
+checksum = "d9a543ae66aa233d14bb765ed9af4a33e81b8b58d1584cf1b47ff8cd0b9e4489"
 
 [[package]]
 name = "web-sys"
-version = "0.3.48"
+version = "0.3.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec600b26223b2948cedfde2a0aa6756dcf1fef616f43d7b3097aaf53a6c4d92b"
+checksum = "a905d57e488fec8861446d3393670fb50d27a262344013181c2cdf9fff5481be"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,9 +2,9 @@
 # It is not intended for manual editing.
 [[package]]
 name = "adler"
-version = "0.2.3"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee2a4ec343196209d6594e19543ae87a39f96d5534d7174822a3ad825dd6ed7e"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "ansi_term"
@@ -66,9 +66,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.6.0"
+version = "3.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "099e596ef14349721d9016f6b80dd3419ea1bf289ab9b44df8e4dfd3a005d5d9"
+checksum = "63396b8a4b9de3f4fdfb320ab6080762242f66a8ef174c49d8e19b674db4cdbe"
 
 [[package]]
 name = "byteorder"
@@ -90,9 +90,9 @@ checksum = "b700ce4376041dcd0a327fd0097c41095743c4c8af8887265942faf1100bd040"
 
 [[package]]
 name = "cc"
-version = "1.0.66"
+version = "1.0.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c0496836a84f8d0495758516b8621a622beb77c0fed418570e50764093ced48"
+checksum = "e3c69b077ad434294d3ce9f1f6143a2a4b89a8a2d54ef813d85003a4fd1137fd"
 
 [[package]]
 name = "cfg-if"
@@ -109,7 +109,6 @@ dependencies = [
  "libc",
  "num-integer",
  "num-traits",
- "time",
  "winapi",
 ]
 
@@ -118,12 +117,6 @@ name = "const-sha1"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb58b6451e8c2a812ad979ed1d83378caa5e927eef2622017a45f251457c2c9d"
-
-[[package]]
-name = "const_fn"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28b9d6de7f49e22cf97ad17fc4036ece69300032f45f78f30b4a4482cdc3f4a6"
 
 [[package]]
 name = "core-foundation"
@@ -179,12 +172,11 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.1"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1aaa739f95311c2c7887a76863f500026092fb1dce0161dab577e559ef3569d"
+checksum = "2584f639eb95fea8c798496315b297cf81b9b58b6d30ab066a75455333cf4b12"
 dependencies = [
  "cfg-if",
- "const_fn",
  "crossbeam-utils",
  "lazy_static",
  "memoffset",
@@ -193,9 +185,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.1"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02d96d1e189ef58269ebe5b97953da3274d83a93af647c2ddd6f9dab28cedb8d"
+checksum = "e7e9d99fa91428effe99c5c6d4634cdeba32b8cf784fc428a2a687f61a952c49"
 dependencies = [
  "autocfg",
  "cfg-if",
@@ -263,9 +255,9 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "form_urlencoded"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ece68d15c92e84fa4f19d3780f1294e5ca82a78a6d515f1efaabcc144688be00"
+checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
 dependencies = [
  "matches",
  "percent-encoding",
@@ -273,9 +265,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da9052a1a50244d8d5aa9bf55cbc2fb6f357c86cc52e46c62ed390a7180cf150"
+checksum = "7f55667319111d593ba876406af7c409c0ebb44dc4be6132a783ccf163ea14c1"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -288,9 +280,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2d31b7ec7efab6eefc7c57233bb10b847986139d88cc2f5a02a1ae6871a1846"
+checksum = "8c2dd2df839b57db9ab69c2c9d8f3e8c81984781937fe2807dc6dcf3b2ad2939"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -298,15 +290,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79e5145dde8da7d1b3892dad07a9c98fc04bc39892b1ecc9692cf53e2b780a65"
+checksum = "15496a72fabf0e62bdc3df11a59a3787429221dd0710ba8ef163d6f7a9112c94"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9e59fdc009a4b3096bf94f740a0f2424c082521f20a9b08c5c07c48d90fd9b9"
+checksum = "891a4b7b96d84d5940084b2a37632dd65deeae662c114ceaa2c879629c9c0ad1"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -315,15 +307,15 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28be053525281ad8259d47e4de5de657b25e7bac113458555bb4b70bc6870500"
+checksum = "d71c2c65c57704c32f5241c1223167c2c3294fd34ac020c807ddbe6db287ba59"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c287d25add322d9f9abdcdc5927ca398917996600182178774032e9f8258fedd"
+checksum = "ea405816a5139fb39af82c2beb921d52143f556038378d6db21183a5c37fbfb7"
 dependencies = [
  "proc-macro-hack",
  "proc-macro2",
@@ -333,18 +325,15 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caf5c69029bda2e743fddd0582d1083951d65cc9539aebf8812f36c3491342d6"
+checksum = "85754d98985841b7d4f5e8e6fbfa4a4ac847916893ec511a2917ccd8525b8bb3"
 
 [[package]]
 name = "futures-task"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13de07eb8ea81ae445aca7b69f5f7bf15d7bf4912d8ca37d6645c77ae8a58d86"
-dependencies = [
- "once_cell",
-]
+checksum = "fa189ef211c15ee602667a6fcfe1c1fd9e07d42250d2156382820fba33c9df80"
 
 [[package]]
 name = "futures-timer"
@@ -354,9 +343,9 @@ checksum = "e64b03909df88034c26dc1547e8970b91f98bdb65165d6a4e9110d94263dbb2c"
 
 [[package]]
 name = "futures-util"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "632a8cd0f2a4b3fdea1657f08bde063848c3bd00f9bbf6e256b8be78802e624b"
+checksum = "1812c7ab8aedf8d6f2701a43e1243acdbcc2b36ab26e2ad421eb99ac963d96d1"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -406,9 +395,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b67e66362108efccd8ac053abafc8b7a8d86a37e6e48fc4f6f7485eb5e9e6a5"
+checksum = "d832b01df74254fe364568d6ddc294443f61cbec82816b60904303af87efae78"
 dependencies = [
  "bytes 1.0.1",
  "fnv",
@@ -421,7 +410,6 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tracing",
- "tracing-futures",
 ]
 
 [[package]]
@@ -526,9 +514,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.6.1"
+version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fb1fa934250de4de8aef298d81c729a7d33d8c239daa3a7575e6b92bfc7313b"
+checksum = "824845a0bf897a9042383849b02c1bc219c2383772efcd5c6f9766fa4b81aef3"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -560,9 +548,9 @@ checksum = "dd25036021b0de88a0aff6b850051563c6516d0bf53f8638938edbb9de732736"
 
 [[package]]
 name = "js-sys"
-version = "0.3.47"
+version = "0.3.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cfb73131c35423a367daf8cbd24100af0d077668c8c2943f0e7dd775fef0f65"
+checksum = "dc9f84f9b115ce7843d60706df1422a916680bfdfcbdb0447c5614ff9d7e4d78"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -575,9 +563,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.86"
+version = "0.2.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7282d924be3275cec7f6756ff4121987bc6481325397dde6ba3e7802b1a8b1c"
+checksum = "03b07a082330a35e43f63177cc01689da34fbffa0105e1246cf0311472cac73a"
 
 [[package]]
 name = "libz-sys"
@@ -640,9 +628,9 @@ dependencies = [
 
 [[package]]
 name = "miniz_oxide"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f2d26ec3309788e423cfbf68ad1800f061638098d76a83681af979dc4eda19d"
+checksum = "a92518e98c078586bc6c934028adcca4c92a53d6a958196de835170a01d84e4b"
 dependencies = [
  "adler",
  "autocfg",
@@ -650,9 +638,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.7.8"
+version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc250d6848c90d719ea2ce34546fb5df7af1d3fd189d10bf7bad80bfcebecd95"
+checksum = "a5dede4e2065b3842b8b0af444119f3aa331cc7cc2dd20388bfb0f5d5a38823a"
 dependencies = [
  "libc",
  "log",
@@ -711,9 +699,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.5.2"
+version = "1.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13bd41f508810a131401606d54ac32a467c97172d74ba7662562ebba5ad07fa0"
+checksum = "af8b08b04175473088b46763e51ee54da5f9a164bc162f615b91bc179dbf15a3"
 
 [[package]]
 name = "opaque-debug"
@@ -789,9 +777,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.4"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "439697af366c49a6d0a010c56a0d97685bc140ce0d377b13a2ea2aa42d64a827"
+checksum = "dc0e1f259c92177c30a4c9d177246edd0a3568b25756a977d0632cf8fa37e905"
 
 [[package]]
 name = "pin-utils"
@@ -1055,9 +1043,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "2.0.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1759c2e3c8580017a484a7ac56d3abc5a6c1feadf88db2f3633f12ae4268c69"
+checksum = "2dfd318104249865096c8da1dfabf09ddbb6d0330ea176812a62ec75e40c4166"
 dependencies = [
  "bitflags",
  "core-foundation",
@@ -1068,9 +1056,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.0.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f99b9d5e26d2a71633cc4f2ebae7cc9f874044e0c351a27e17892d76dce5678b"
+checksum = "dee48cdde5ed250b0d3252818f646e174ab414036edb884dde62d80a3ac6082d"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -1078,9 +1066,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.123"
+version = "1.0.124"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92d5161132722baa40d802cc70b15262b98258453e85e5d1d365c757c73869ae"
+checksum = "bd761ff957cb2a45fbb9ab3da6512de9de55872866160b23c25f1a841e99d29f"
 dependencies = [
  "serde_derive",
 ]
@@ -1097,9 +1085,9 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.123"
+version = "1.0.124"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9391c295d64fc0abb2c556bad848f33cb8296276b1ad2677d1ae1ace4f258f31"
+checksum = "1800f7693e94e186f5e25a28291ae1570da908aff7d97a095dec1e56ff99069b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1108,9 +1096,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.62"
+version = "1.0.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea1c6153794552ea7cf7cf63b1231a25de00ec90db326ba6264440fa08e31486"
+checksum = "799e97dc9fdae36a5c8b8f2cae9ce2ee9fdce2058c57a93e6099d919fd982f79"
 dependencies = [
  "itoa",
  "ryu",
@@ -1202,9 +1190,9 @@ checksum = "1fccf17fd09e2455ea796d2ad267b64fa2c5cbd8701b2a93b555d2aa73449f7d"
 
 [[package]]
 name = "syn"
-version = "1.0.60"
+version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c700597eca8a5a762beb35753ef6b94df201c81cca676604f547495a0d7f0081"
+checksum = "ed22b90a0e734a23a7610f4283ac9e5acfb96cbb30dfefa540d66f866f1c09c5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1213,9 +1201,9 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.16.3"
+version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3d39c47be321239a7b3d232d733e58b257c6727167e61ee18c87cd2fa2b5b1b"
+checksum = "6c280c91abd1aed2e36be1bc8f56fbc7a2acbb2b58fbcac9641510179cc72dd9"
 dependencies = [
  "cfg-if",
  "core-foundation-sys",
@@ -1254,8 +1242,8 @@ dependencies = [
 
 [[package]]
 name = "taskinator-communicator"
-version = "0.1.0"
-source = "git+https://github.com/sam-kirby/taskinator-communicator.git?branch=main#152594a2ddb5a2f598364431497cad98dba00287"
+version = "0.1.1"
+source = "git+https://github.com/sam-kirby/taskinator-communicator.git?branch=main#f005288e04eba1f0036baf270b7cb458664d5761"
 dependencies = [
  "tracing",
  "windows",
@@ -1268,16 +1256,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8018d24e04c95ac8790716a5987d0fec4f8b27249ffa0f7d33f1369bdfb88cbd"
 dependencies = [
  "once_cell",
-]
-
-[[package]]
-name = "time"
-version = "0.1.43"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
-dependencies = [
- "libc",
- "winapi",
 ]
 
 [[package]]
@@ -1378,9 +1356,9 @@ checksum = "360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6"
 
 [[package]]
 name = "tracing"
-version = "0.1.24"
+version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f77d3842f76ca899ff2dbcf231c5c65813dea431301d6eb686279c15c4464f12"
+checksum = "01ebdc2bb4498ab1ab5f5b73c5803825e60199229ccba0698170e3be0e7f959f"
 dependencies = [
  "cfg-if",
  "pin-project-lite",
@@ -1409,20 +1387,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracing-futures"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
-dependencies = [
- "pin-project",
- "tracing",
-]
-
-[[package]]
 name = "tracing-log"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e0f8c7178e13481ff6765bd169b33e8d554c5d2bbede5e32c356194be02b9b9"
+checksum = "a6923477a48e41c1951f1999ef8bb5a3023eb723ceadafe78ffb65dc366761e3"
 dependencies = [
  "lazy_static",
  "log",
@@ -1441,9 +1409,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1fa8f0c8f4c594e4fc9debc1990deab13238077271ba84dd853d54902ee3401"
+checksum = "8ab8966ac3ca27126141f7999361cc97dd6fb4b71da04c02044fa9045d98bb96"
 dependencies = [
  "ansi_term",
  "chrono",
@@ -1663,9 +1631,9 @@ checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "url"
-version = "2.2.0"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5909f2b0817350449ed73e8bcd81c8c3c8d9a7a5d8acba4b27db277f1868976e"
+checksum = "9ccd964113622c8e9322cfac19eb1004a07e636c545f325da085d5cdde6f1f8b"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -1715,9 +1683,9 @@ checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.70"
+version = "0.2.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55c0f7123de74f0dab9b7d00fd614e7b19349cd1e2f5252bbe9b1754b59433be"
+checksum = "7ee1280240b7c461d6a0071313e08f34a60b0365f14260362e5a2b17d1d31aa7"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -1725,9 +1693,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.70"
+version = "0.2.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bc45447f0d4573f3d65720f636bbcc3dd6ce920ed704670118650bcd47764c7"
+checksum = "5b7d8b6942b8bb3a9b0e73fc79b98095a27de6fa247615e59d096754a3bc2aa8"
 dependencies = [
  "bumpalo",
  "lazy_static",
@@ -1740,9 +1708,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.70"
+version = "0.2.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b8853882eef39593ad4174dd26fc9865a64e84026d223f63bb2c42affcbba2c"
+checksum = "e5ac38da8ef716661f0f36c0d8320b89028efe10c7c0afde65baffb496ce0d3b"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1750,9 +1718,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.70"
+version = "0.2.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4133b5e7f2a531fa413b3a1695e925038a05a71cf67e87dafa295cb645a01385"
+checksum = "cc053ec74d454df287b9374ee8abb36ffd5acb95ba87da3ba5b7d3fe20eb401e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1763,15 +1731,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.70"
+version = "0.2.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd4945e4943ae02d15c13962b38a5b1e81eadd4b71214eee75af64a4d6a4fd64"
+checksum = "7d6f8ec44822dd71f5f221a5847fb34acd9060535c1211b70a05844c0f6383b1"
 
 [[package]]
 name = "web-sys"
-version = "0.3.47"
+version = "0.3.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c40dc691fc48003eba817c38da7113c15698142da971298003cac3ef175680b3"
+checksum = "ec600b26223b2948cedfde2a0aa6756dcf1fef616f43d7b3097aaf53a6c4d92b"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "taskinator"
-version = "0.2.2"
+version = "0.3.0-alpha"
 authors = ["Sam Kirby <sam.kirby94@hotmail.co.uk>"]
 edition = "2018"
 license = "AGPL-3.0-or-later"
@@ -12,6 +12,8 @@ lto = true
 [dependencies]
 futures = "0.3"
 parking_lot = "0.11"
+sysinfo = "0.16"
+taskinator-communicator = { path = "../taskinator-communicator" }
 tokio-stream = "0.1"
 toml = "0.5"
 tracing = "0.1"
@@ -32,4 +34,4 @@ features = ["derive"]
 
 [dependencies.tokio]
 version = "1"
-features = ["rt-multi-thread", "signal", "sync", "time"]
+features = ["rt-multi-thread", "macros", "signal", "sync", "time"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ lto = true
 futures = "0.3"
 parking_lot = "0.11"
 sysinfo = "0.16"
-taskinator-communicator = { path = "../taskinator-communicator" }
+taskinator-communicator = { git = "https://github.com/sam-kirby/taskinator-communicator.git", branch = "main" }
 tokio-stream = "0.1"
 toml = "0.5"
 tracing = "0.1"

--- a/readme.md
+++ b/readme.md
@@ -1,18 +1,14 @@
-# Taskinator 5000
+# Taskinator
 
 ## Overview
 
-This is a simple Discord bot to assist with running a game of Among Us! It's here to help you stay focussed on who was near the body, not whether you remembered to unmute yourself on Discord.
+Taskinator is a Discord bot that automatically mutes and unmutes players on Discord during a game of Among Us.
 
-Only one person needs the bot installed, and is designed to help when you have players who are less tech savvy.
+At the beginning of the game, all players are automatically muted. When a meeting is called, the bot automatically unmutes anyone who is still alive - usually within 2 seconds. At the end of a meeting, the bot will either mute players if they are still alive, or move them to a separate channel where the dead players can hang out and openly discuss what's going on. At the end of the game all players are unmuted an moved back to the original channel.
 
-When a game begins, one player needs to execute the `~new` command. They are now the game master, and all players will be muted after 5 seconds.
+The bot must be run by the Among Us game host or it will fail to detect the end of meetings.
 
-When a body is found, or an emergency meeting begins, the game master needs to click the 🔴 reaction to the bots message. This will unmute all players who are still alive and move dead players back to the channel.
-
-When the meeting is over, the game master should remove their reaction on 🔴 and the bot will again mute living players. Dead players will be moved to a separate channel where they can freely discuss the game.
-
-A player marks themself as dead by clicking the 💀 reaction during a meeting (immediately muting them), or for those less techy players an admin can run `~dead @Player` to achieve the same effect.
+The bot must be able to match Discord Users to Among Us Players. If your nickname is the same on Discord as your player name in Among Us, it does this automatically. Otherwise you can use the `~ident <IN_GAME_NAME>` to set your alias. Use the `~check` command to confirm all players are matched to Discord users.
 
 ## Configuration
 
@@ -20,12 +16,12 @@ To run the bot, you need to create a `Config.toml` file in the directory you are
 
 ```toml
 token = "BOT_TOKEN"
-living_channel = "CHANNEL_ID"
-dead_channel = "CHANNEL_ID"
-spectator_role = "ROLE_ID"
+living_channel = "VOICE_CHANNEL_ID"
+dead_channel = "VOICE_CHANNEL_ID"
+broadcast_channel = "TEXT_CHANNEL_ID"
 ```
 
-The `token` is your Discord bot token. Make sure you add the bot user to the server you are chatting in.
+The `token` is your Discord bot token. Make sure you add the bot user to the server you are chatting in with appropriate permissions.
 
 The `living_channel` and `dead_channel` are the IDs of the channels which the bot will moderate. You can get a channel ID by turning on developer mode in Discord, then right clicking the channel name and choosing Copy ID.
 
@@ -33,21 +29,17 @@ The `spectator_role` is important if you have more than 10 people on the server.
 
 ## Running
 
-Builds are provided via Github Actions. Simply download the executable for your OS and place it in the same directory as the config file before running it.
+Builds are provided via Github Actions. Simply download the executable and place it in the same directory as the config file before running it.
 
 ## Building
 
 ### Requirements
 
-* Rust compiler (>1.48.0)
-* Git or a copy of the source code
+- Rust compiler (>1.48.0)
+- Git or a copy of the source code
 
 ### Steps
 
-1) Navigate to the source directory
-2) Create the configuration file as described above
-3) Execute `cargo run --release`
-
-## Possible future additions
-
-* Automatic detection of emergency meetings and dead players.
+1. Navigate to the source directory
+2. Create the configuration file as described above
+3. Execute `cargo run --release`

--- a/src/bot.rs
+++ b/src/bot.rs
@@ -1,59 +1,67 @@
+use std::{
+    collections::{HashMap, HashSet},
+    fmt::Debug,
+    future::Future,
+    path::Path,
+    sync::Arc,
+};
+
+use futures::StreamExt;
+use parking_lot::RwLock;
+use taskinator_communicator::game::{MeetingState, Player, State};
+use tokio::{signal::ctrl_c, sync::watch::Receiver};
+use twilight_cache_inmemory::{model::CachedMember, InMemoryCache, ResourceType};
+use twilight_command_parser::{Arguments, Command, CommandParserConfig, Parser};
+use twilight_embed_builder::{EmbedBuilder, EmbedFieldBuilder};
+use twilight_gateway::{Event, EventTypeFlags, Intents, Shard};
+use twilight_http::{Client, Result as TwiResult};
+use twilight_mention::{Mention, ParseMention};
+use twilight_model::{
+    channel::{Channel, GuildChannel, Message},
+    id::{ChannelId, UserId},
+};
+
 use crate::{
     config::Config,
-    constants::{DEAD_EMOJI, EMER_EMOJI},
+    utils::{KnownAs, ReplyTo},
     Result,
 };
 
-use std::{
-    collections::HashSet, fmt::Debug, future::Future, path::Path, sync::Arc, time::Duration,
-};
-
-use parking_lot::RwLock;
-use tokio::{signal::ctrl_c, task::JoinHandle, time::sleep};
-use tracing::{debug, error, info, warn};
-use twilight_cache_inmemory::{model::CachedMember, InMemoryCache as DiscordCache, ResourceType};
-use twilight_command_parser::{Arguments, Command, CommandParserConfig, Parser};
-use twilight_gateway::{shard::Events, Event, EventTypeFlags, Intents, Shard};
-use twilight_http::{
-    error::Result as TwiResult,
-    request::channel::{message::CreateMessage, reaction::RequestReactionType},
-    Client as DiscordHttp,
-};
-use twilight_mention::{Mention, ParseMention};
-use twilight_model::{
-    channel::GuildChannel,
-    channel::{Message, Reaction, ReactionType},
-    id::{ChannelId, GuildId, MessageId, UserId},
-};
-
-struct Game {
-    dead: HashSet<UserId>,
-    ctrl_channel: ChannelId,
-    ctrl_msg: MessageId,
-    ctrl_user: UserId,
-    guild_id: GuildId,
-    meeting_in_progress: bool,
+pub struct Builder {
+    cache: InMemoryCache,
+    discord_gateway: Shard,
+    discord_client: Client,
+    command_parser: Arc<Parser<'static>>,
+    broadcast_channel: ChannelId,
+    living_channel: ChannelId,
+    dead_channel: ChannelId,
 }
 
-#[derive(Clone)]
-pub struct Bot<'p> {
-    bot_id: Option<UserId>,
-    cache: DiscordCache,
-    config: Arc<Config>,
-    discord_http: DiscordHttp,
-    game: Arc<RwLock<Option<Game>>>,
-    owners: Arc<RwLock<Option<HashSet<UserId>>>>,
-    parser: Arc<Parser<'p>>,
-    shard: Shard,
-}
+impl Builder {
+    pub fn new(config_path: impl AsRef<Path>) -> Self {
+        let config = match Config::from_file(config_path) {
+            Ok(config) => config,
+            Err(why) => {
+                tracing::error!("Failed to read the config file. Aborting!");
+                tracing::error!("{}", why);
+                panic!();
+            }
+        };
 
-impl Bot<'_> {
-    pub fn new(config_path: impl AsRef<Path>) -> Result<Self> {
-        let config = Arc::new(Config::from_file(config_path)?);
+        let discord_client = Client::new(&config.token);
 
-        let discord_http = DiscordHttp::new(&config.token);
+        let discord_gateway = Shard::new(
+            &config.token,
+            Intents::GUILDS | Intents::GUILD_MESSAGES | Intents::GUILD_VOICE_STATES,
+        );
 
-        let cache = DiscordCache::builder()
+        let (broadcast_channel, living_channel, dead_channel) = (
+            config.broadcast_channel,
+            config.living_channel,
+            config.dead_channel,
+        );
+
+        let cache = InMemoryCache::builder()
             .resource_types(
                 ResourceType::CHANNEL
                     | ResourceType::GUILD
@@ -63,148 +71,205 @@ impl Bot<'_> {
             )
             .build();
 
-        let shard = Shard::new(
-            &config.token,
-            Intents::GUILDS
-                | Intents::GUILD_MESSAGES
-                | Intents::GUILD_MESSAGE_REACTIONS
-                | Intents::GUILD_VOICE_STATES,
-        );
-
-        let parser = {
+        let command_parser = {
             let mut parser_config = CommandParserConfig::new();
             parser_config.add_prefix("~");
-            parser_config.add_command("new", false);
-            parser_config.add_command("end", false);
-            parser_config.add_command("dead", false);
+            parser_config.add_command("ident", false);
+            parser_config.add_command("check", false);
             parser_config.add_command("stop", false);
 
             Arc::new(Parser::new(parser_config))
         };
 
-        Ok(Bot {
-            bot_id: None,
+        Builder {
             cache,
-            config,
-            discord_http,
-            game: Arc::new(RwLock::new(None)),
-            owners: Arc::new(RwLock::new(None)),
-            parser,
-            shard,
-        })
+            discord_gateway,
+            discord_client,
+            command_parser,
+            broadcast_channel,
+            living_channel,
+            dead_channel,
+        }
     }
 
-    pub async fn fetch_app_details(&mut self) -> Result<()> {
-        let (owners, current_user) = {
+    pub async fn build(self, game_state_rx: Receiver<Option<State>>) -> Result<Bot> {
+        let (owners, bot_id) = {
             let mut owners = HashSet::new();
 
-            let app_info = self.discord_http.current_user_application().await?;
+            let app_info = self.discord_client.current_user_application().await?;
             if let Some(team) = app_info.team {
                 owners.extend(team.members.iter().map(|tm| tm.user.id));
             } else {
                 owners.insert(app_info.owner.id);
             }
-            (owners, UserId(app_info.id.0))
+            (Arc::new(owners), UserId(app_info.id.0))
         };
 
-        self.owners.write().replace(owners);
-        self.bot_id.replace(current_user);
+        // Validate channels
+        let broadcast_channel = if let Channel::Guild(channel) = self
+            .discord_client
+            .channel(self.broadcast_channel)
+            .await?
+            .unwrap()
+        {
+            if let GuildChannel::Text(tc) = channel {
+                tc
+            } else {
+                tracing::error!("Broadcast channel must be a text channel");
+                panic!();
+            }
+        } else {
+            tracing::error!("Broadcast channel must be in a guild.");
+            panic!();
+        };
 
-        Ok(())
+        let living_channel = if let Channel::Guild(channel) = self
+            .discord_client
+            .channel(self.living_channel)
+            .await?
+            .unwrap()
+        {
+            if let GuildChannel::Voice(vc) = channel {
+                vc
+            } else {
+                tracing::error!("Living channel must be a voice channel");
+                panic!();
+            }
+        } else {
+            tracing::error!("Living channel must be in a guild.");
+            panic!();
+        };
+
+        let dead_channel = if let Channel::Guild(channel) = self
+            .discord_client
+            .channel(self.dead_channel)
+            .await?
+            .unwrap()
+        {
+            if let GuildChannel::Voice(vc) = channel {
+                vc
+            } else {
+                tracing::error!("Dead channel must be a voice channel");
+                panic!();
+            }
+        } else {
+            tracing::error!("Dead channel must be in a guild.");
+            panic!();
+        };
+
+        Ok(Bot {
+            cache: self.cache,
+            discord_gateway: self.discord_gateway,
+            discord_client: self.discord_client,
+            command_parser: self.command_parser,
+            bot_id,
+            owners,
+            broadcast_channel: broadcast_channel.id,
+            living_channel: living_channel.id,
+            dead_channel: dead_channel.id,
+            player_names: Arc::new(RwLock::new(HashMap::new())),
+            game_state_rx,
+        })
     }
+}
 
-    pub async fn start_gateway(&mut self) -> Result<Events> {
-        let shutdown_handle = self.shard.clone();
+#[derive(Clone, Debug)]
+pub struct Bot {
+    cache: InMemoryCache,
+    discord_gateway: Shard,
+    discord_client: Client,
+    command_parser: Arc<Parser<'static>>,
+    bot_id: UserId,
+    owners: Arc<HashSet<UserId>>,
+    broadcast_channel: ChannelId,
+    living_channel: ChannelId,
+    dead_channel: ChannelId,
+    player_names: Arc<RwLock<HashMap<UserId, String>>>,
+    game_state_rx: Receiver<Option<State>>,
+}
+
+impl Bot {
+    pub async fn start(&mut self) -> Result<()> {
+        let shutdown_handle = self.discord_gateway.clone();
+
         tokio::spawn(async move {
-            if let Err(e) = ctrl_c().await {
-                error!("Error registering ctrl+c handler!\n{}", e);
+            if let Err(why) = ctrl_c().await {
+                tracing::error!("There was an error registering the ctrl+c handler");
+                tracing::error!("{}", why);
             }
 
             shutdown_handle.shutdown();
         });
 
-        self.shard.start().await?;
+        self.discord_gateway.start().await?;
 
         let event_flags: EventTypeFlags = EventTypeFlags::GUILD_CREATE
             | EventTypeFlags::MESSAGE_CREATE
-            | EventTypeFlags::MESSAGE_DELETE
-            | EventTypeFlags::REACTION_ADD
-            | EventTypeFlags::REACTION_REMOVE
             | EventTypeFlags::VOICE_STATE_UPDATE;
 
-        Ok(self.shard.some_events(event_flags))
-    }
+        let mut events = self.discord_gateway.some_events(event_flags);
 
-    pub fn update_cache(&self, event: &Event) {
-        self.cache.update(event);
-    }
-
-    pub fn bot_id(&self) -> UserId {
-        self.bot_id
-            .expect("Expected bot ID - must fetch app info first!")
-    }
-
-    pub async fn process_command(&self, msg: &Message) -> Result<()> {
-        match self.parser.parse(&msg.content) {
-            Some(Command {
-                name: "new",
-                arguments,
-                ..
-            }) => {
-                self.discord_http
-                    .delete_message(msg.channel_id, msg.id)
-                    .await?;
-                self.begin_game(msg, arguments).await?
-            }
-            Some(Command { name: "end", .. }) => {
-                self.discord_http
-                    .delete_message(msg.channel_id, msg.id)
-                    .await?;
-
-                if self.is_in_control(msg.author.id) {
-                    self.end_game().await?;
+        let mut bot = self.clone();
+        tokio::spawn(async move {
+            let mut in_meeting = true;
+            let mut in_game = false;
+            loop {
+                if let Err(why) = bot.game_state_rx.changed().await {
+                    tracing::error!("Game state receive failed: {}", why);
+                    break;
                 }
-            }
-            Some(Command {
-                name: "dead",
-                arguments,
-                ..
-            }) => {
-                self.discord_http
-                    .delete_message(msg.channel_id, msg.id)
-                    .await?;
-
-                self.deadify(msg, arguments).await?;
-            }
-            Some(Command { name: "stop", .. }) => {
-                self.discord_http
-                    .delete_message(msg.channel_id, msg.id)
-                    .await?;
-
-                if self.is_in_control(msg.author.id) {
-                    if self.is_game_in_progress() {
-                        self.end_game().await?;
+                let state = bot.game_state_rx.borrow().as_ref().map(|s| (*s).clone());
+                match state {
+                    Some(State::InGame { meeting, .. })
+                        if matches!(
+                            meeting,
+                            MeetingState::Discussion
+                                | MeetingState::NotVoted
+                                | MeetingState::Voted
+                                | MeetingState::Results
+                        ) =>
+                    {
+                        // In a meeting
+                        if !in_meeting {
+                            in_meeting = true;
+                            bot.start_meeting().await;
+                        }
+                        if !in_game {
+                            in_game = true;
+                        }
                     }
-
-                    self.shard.shutdown();
-                }
-            }
-            _ => {}
-        }
-
-        Ok(())
-    }
-
-    pub async fn reaction_add_handler(&self, reaction: &Reaction) -> Result<()> {
-        if self.is_reacting_to_control(&reaction) {
-            match reaction.emoji {
-                ReactionType::Unicode { ref name } if name == EMER_EMOJI => {
-                    if self.is_in_control(reaction.user_id) {
-                        self.begin_meeting().await?;
+                    Some(State::InGame { .. }) => {
+                        // In gameplay
+                        if in_meeting {
+                            in_meeting = false;
+                            bot.end_meeting().await;
+                        }
+                        if !in_game {
+                            in_game = true;
+                        }
+                    }
+                    Some(State::Lobby { .. }) | Some(State::Menu) | None => {
+                        // No game running or crash
+                        if in_game {
+                            in_meeting = true;
+                            in_game = false;
+                            bot.end_game().await;
+                        }
                     }
                 }
-                ReactionType::Unicode { ref name } if name == DEAD_EMOJI => {
-                    self.make_dead(reaction.user_id).await;
+            }
+        });
+
+        while let Some(event) = events.next().await {
+            self.cache.update(&event);
+
+            match event {
+                Event::MessageCreate(message) if !message.author.bot => {
+                    if let Err(why) = self.handle_command(&message).await {
+                        tracing::error!("An error occurred whilst processing a command!");
+                        tracing::error!("Message: {:?}", &message);
+                        tracing::error!("Error: {}", why);
+                    }
                 }
                 _ => {}
             }
@@ -213,281 +278,257 @@ impl Bot<'_> {
         Ok(())
     }
 
-    pub async fn reaction_remove_handler(&self, reaction: &Reaction) -> Result<()> {
-        if self.is_reacting_to_control(&reaction)
-            && self.is_in_control(reaction.user_id)
-            && matches!(reaction.emoji, ReactionType::Unicode { ref name } if name == EMER_EMOJI)
-        {
-            self.end_meeting().await?;
-        }
-
-        Ok(())
-    }
-
-    async fn begin_game(&self, msg: &Message, mut args: Arguments<'_>) -> Result<()> {
-        info!("Initiating new game");
-
-        let ctrl_msg = self
-            .discord_http
-            .create_message(msg.channel_id)
-            .content(format!(
-                "A game is in progress, {} can react to this message with {} to call a \
-             meeting.\nAnyone can react to this message with {} to access dead chat \
-             after the next meeting",
-                msg.author.mention(),
-                EMER_EMOJI,
-                DEAD_EMOJI
-            ))?
-            .await?;
-
-        let discord_http = self.discord_http.clone();
-        let reaction_ctrl_msg = ctrl_msg.clone();
-
-        // Adding emoji takes ~1 second; don't hold up starting a game by doing it concurrently
-        let res: JoinHandle<Result<()>> = tokio::spawn(async move {
-            let emojis = vec![
-                RequestReactionType::Unicode {
-                    name: EMER_EMOJI.into(),
-                },
-                RequestReactionType::Unicode {
-                    name: DEAD_EMOJI.into(),
-                },
-            ];
-
-            for emoji in emojis {
-                discord_http
-                    .create_reaction(reaction_ctrl_msg.channel_id, reaction_ctrl_msg.id, emoji)
-                    .await?;
-            }
-
-            Ok(())
-        });
-
-        self.game.write().replace(Game {
-            dead: HashSet::new(),
-            ctrl_channel: msg.channel_id,
-            ctrl_msg: ctrl_msg.id,
-            ctrl_user: msg.author.id,
-            guild_id: msg.guild_id.unwrap(),
-            meeting_in_progress: false,
-        });
-
-        let duration = match args.next().and_then(|s| s.parse().ok()) {
-            Some(time) if time == 0 => None,
-            Some(time) => Some(Duration::from_secs(time)),
-            None => Some(Duration::from_secs(5)),
-        };
-
-        if let Some(duration) = duration {
-            sleep(duration).await;
-        }
-
-        self.end_meeting().await?;
-
-        res.await??;
-
-        Ok(())
-    }
-
-    async fn end_game(&self) -> Result<()> {
-        info!("Ending game");
-
-        let game = self.game.write().take();
-        if let Some(game) = game {
-            self.discord_http
-                .delete_message(game.ctrl_channel, game.ctrl_msg)
-                .await?;
-        } else {
-            return Ok(());
-        }
-
-        let living_channel = self
-            .cache
-            .guild_channel(self.config.living_channel)
-            .unwrap();
-        let dead_channel = self.cache.guild_channel(self.config.dead_channel).unwrap();
-
-        let mut futures = Vec::new();
-
-        for member in self.get_members_in_channel(&living_channel) {
-            futures.push(
-                self.discord_http
-                    .update_guild_member(member.guild_id, member.user.id)
-                    .mute(false),
-            );
-        }
-
-        for member in self.get_members_in_channel(&dead_channel) {
-            futures.push(
-                self.discord_http
-                    .update_guild_member(member.guild_id, member.user.id)
-                    .channel_id(self.config.living_channel),
-            );
-        }
-
-        self.batch(futures).await;
-
-        Ok(())
-    }
-
-    async fn begin_meeting(&self) -> Result<()> {
-        debug!("Meeting initiated");
-
-        let living_channel = self
-            .cache
-            .guild_channel(self.config.living_channel)
-            .unwrap();
-        let dead_channel = self.cache.guild_channel(self.config.dead_channel).unwrap();
-
-        let mut futures = Vec::new();
-
-        {
-            let game_lock = self.game.read();
-            let game = game_lock.as_ref().unwrap();
-
-            for member in self.get_members_in_channel(&living_channel) {
-                if game.dead.contains(&member.user.id) {
-                    continue;
+    async fn handle_command(&self, message: &Message) -> Result<()> {
+        match self.command_parser.parse(&message.content) {
+            Some(Command {
+                name: "ident",
+                mut arguments,
+                ..
+            }) => self.ident_player(&message, &mut arguments).await?,
+            Some(Command { name: "check", .. }) => self.check_matching(&message).await?,
+            Some(Command { name: "stop", .. }) => {
+                if self.owners.contains(&message.author.id) {
+                    self.discord_client
+                        .create_message(message.channel_id)
+                        .content("Good night")?
+                        .reply(message.id)
+                        .await?;
+                    self.discord_gateway.shutdown();
                 }
-                futures.push(
-                    self.discord_http
-                        .update_guild_member(member.guild_id, member.user.id)
+            }
+            _ => {}
+        }
+
+        Ok(())
+    }
+
+    async fn start_meeting(&self) {
+        tracing::info!("Start meeting");
+
+        let mut futs = self
+            .match_members_to_players(&self.get_members_in_channel(self.living_channel))
+            .unwrap()
+            .iter()
+            .filter_map(|(m, p)| match p {
+                Some(p) if !p.dead => Some(
+                    self.discord_client
+                        .update_guild_member(m.guild_id, m.user.id)
                         .mute(false),
-                );
-            }
-        }
+                ),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
 
-        for member in self.get_members_in_channel(&dead_channel) {
-            futures.push(
-                self.discord_http
-                    .update_guild_member(member.guild_id, member.user.id)
-                    .channel_id(self.config.living_channel)
-                    .mute(true),
-            )
-        }
+        futs.extend(
+            self.get_members_in_channel(self.dead_channel)
+                .iter()
+                .map(|m| {
+                    self.discord_client
+                        .update_guild_member(m.guild_id, m.user.id)
+                        .channel_id(self.living_channel)
+                        .mute(true)
+                }),
+        );
 
-        self.batch(futures).await;
-
-        let mut game_lock = self.game.write();
-        let g = game_lock.as_mut().expect("expected game");
-        g.meeting_in_progress = true;
-
-        Ok(())
+        self.batch(futs).await;
     }
 
-    async fn end_meeting(&self) -> Result<()> {
-        debug!("Ending meeting");
+    async fn end_meeting(&self) {
+        tracing::info!("End meeting");
 
-        let living_channel = self
-            .cache
-            .guild_channel(self.config.living_channel)
-            .unwrap();
+        let futs = self
+            .match_members_to_players(&self.get_members_in_channel(self.living_channel))
+            .unwrap()
+            .iter()
+            .filter_map(|(m, p)| match p {
+                Some(p) if p.dead => Some(
+                    self.discord_client
+                        .update_guild_member(m.guild_id, m.user.id)
+                        .channel_id(self.dead_channel)
+                        .mute(false),
+                ),
+                Some(p) if !p.dead => Some(
+                    self.discord_client
+                        .update_guild_member(m.guild_id, m.user.id)
+                        .mute(true),
+                ),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
 
-        let (alive_players, dead_players): (Vec<_>, Vec<_>) = {
-            let game_lock = self.game.read();
-            let game = game_lock.as_ref().unwrap();
-
-            self.get_members_in_channel(&living_channel)
-                .into_iter()
-                .partition(|p| !game.dead.contains(&p.user.id))
-        };
-
-        let mut futures = Vec::new();
-
-        for player in alive_players {
-            futures.push(
-                self.discord_http
-                    .update_guild_member(player.guild_id, player.user.id)
-                    .mute(true),
-            );
-        }
-
-        for player in dead_players {
-            futures.push(
-                self.discord_http
-                    .update_guild_member(player.guild_id, player.user.id)
-                    .channel_id(self.config.dead_channel)
-                    .mute(false),
-            );
-        }
-
-        self.batch(futures).await;
-
-        let mut game_lock = self.game.write();
-        let g = game_lock.as_mut().expect("expected game");
-        g.meeting_in_progress = false;
-
-        Ok(())
+        self.batch(futs).await;
     }
 
-    async fn deadify(&self, msg: &Message, mut args: Arguments<'_>) -> Result<()> {
-        if let Some(broadcast) = self.broadcast() {
-            if self.is_in_control(msg.author.id) {
-                match args.next().map(UserId::parse) {
-                    Some(Ok(target)) => {
-                        let reply = broadcast
-                            .content(format!("deadifying {}", target.mention()))?
-                            .await?;
-                        self.make_dead(target).await;
-                        sleep(Duration::from_secs(5)).await;
-                        self.discord_http
-                            .delete_message(reply.channel_id, reply.id)
-                            .await?;
-                    }
-                    _ => {
-                        broadcast
-                            .content("You must mention the user you wish to die")?
-                            .await?;
-                    }
+    async fn end_game(&self) {
+        tracing::info!("End game");
+
+        let mut futs = self
+            .get_members_in_channel(self.living_channel)
+            .iter()
+            .filter_map(|m| {
+                if m.mute {
+                    Some(
+                        self.discord_client
+                            .update_guild_member(m.guild_id, m.user.id)
+                            .mute(false),
+                    )
+                } else {
+                    None
                 }
-            } else {
-                broadcast
-                    .content(
-                        "You must have started the game or be an owner of the bot to make \
-                         others dead\nTo make yourself dead, please use the reactions",
-                    )?
+            })
+            .collect::<Vec<_>>();
+
+        futs.extend(
+            self.get_members_in_channel(self.dead_channel)
+                .iter()
+                .map(|m| {
+                    self.discord_client
+                        .update_guild_member(m.guild_id, m.user.id)
+                        .channel_id(self.living_channel)
+                }),
+        );
+
+        self.batch(futs).await;
+    }
+
+    async fn ident_player(&self, message: &Message, arguments: &mut Arguments<'_>) -> Result<()> {
+        match arguments.next() {
+            Some(argument) => {
+                if let Ok(target) = UserId::parse(argument) {
+                    if self.owners.contains(&message.author.id) {
+                        if let Some(ign) = arguments.next() {
+                            self.player_names.write().insert(target, ign.to_owned());
+                            message
+                                .reply(
+                                    &self.discord_client,
+                                    format!("Set {}'s IGN to {}", target.mention(), ign),
+                                )?
+                                .await?;
+                        } else {
+                            message
+                                .reply(&self.discord_client, "You must include an in game name")?
+                                .await?;
+                        }
+                    } else {
+                        message
+                            .reply(
+                                &self.discord_client,
+                                "Only owners can set the in game name of another user",
+                            )?
+                            .await?;
+                    }
+                } else {
+                    self.player_names
+                        .write()
+                        .insert(message.author.id, argument.to_owned());
+                    message
+                        .reply(
+                            &self.discord_client,
+                            format!("Set your in game name to {}", argument),
+                        )?
+                        .await?;
+                }
+            }
+            None => {
+                message
+                    .reply(&self.discord_client, "Please include your in game name")?
                     .await?;
             }
-        } else {
-            self.discord_http
-                .create_message(msg.channel_id)
-                .content("There is no game running")?
-                .await?;
-        }
+        };
 
         Ok(())
     }
 
-    async fn make_dead(&self, target: UserId) {
-        let mut fut = None;
+    async fn check_matching(&self, message: &Message) -> Result<()> {
+        match self.match_members_to_players(&self.get_members_in_channel(self.living_channel)) {
+            Some(matched_players) => {
+                tracing::trace!("{:?}", matched_players);
+                let unmatched_players = matched_players
+                    .into_iter()
+                    .filter_map(|(m, p)| if p.is_none() { Some(m.user.id) } else { None })
+                    .collect::<Vec<_>>();
 
-        if let Some(game) = self.game.write().as_mut() {
-            if game.dead.insert(target) && game.meeting_in_progress {
-                let guild_id = game.guild_id;
-
-                if let Some(target_member) = self.cache.member(guild_id, target) {
-                    let name = match &target_member.nick {
-                        Some(nick) => nick,
-                        None => &target_member.user.name,
-                    };
-                    info!("{} is now dead", name);
+                if unmatched_players.is_empty() {
+                    self.discord_client
+                        .create_message(message.channel_id)
+                        .content("All members matched to player")?
+                        .reply(message.id)
+                        .await?;
                 } else {
-                    warn!("{} is now dead\t!!cache miss!!", target);
+                    let embed = EmbedBuilder::new()
+                        .description("Could not match all members to players")?
+                        .color(0xFF_00_00)?;
+
+                    let embed = unmatched_players.iter().fold(embed, |embed, uid| {
+                        embed.field(
+                            EmbedFieldBuilder::new("not found", format!("{}", uid.mention()))
+                                .unwrap()
+                                .build(),
+                        )
+                    });
+
+                    self.discord_client
+                        .create_message(message.channel_id)
+                        .embed(embed.build()?)?
+                        .await?;
                 }
-
-                fut = Some(
-                    self.discord_http
-                        .update_guild_member(guild_id, target)
-                        .mute(true),
-                );
             }
-        }
-
-        if let Some(fut) = fut {
-            if let Err(why) = fut.await {
-                error!("Error occured when making {} dead\n{}", target, why);
+            None => {
+                self.discord_client
+                    .create_message(message.channel_id)
+                    .content("Must be in a lobby to check")?
+                    .reply(message.id)
+                    .await?;
             }
-        }
+        };
+
+        Ok(())
+    }
+
+    fn match_members_to_players(
+        &self,
+        members: &[Arc<CachedMember>],
+    ) -> Option<Vec<(Arc<CachedMember>, Option<Player>)>> {
+        let game_state = self.game_state_rx.borrow();
+        let players = match game_state.as_ref() {
+            Some(State::Lobby { players }) | Some(State::InGame { players, .. }) => Some(players),
+            Some(_) | None => None,
+        };
+
+        players.map(|players| {
+            members
+                .iter()
+                .map(|m| {
+                    let ign = match self.player_names.read().get(&m.user.id) {
+                        Some(ign) => ign.to_owned(),
+                        None => m.known_as(),
+                    };
+                    (
+                        m.clone(),
+                        players.iter().find_map(
+                            |p| {
+                                if p.name == ign {
+                                    Some(p.clone())
+                                } else {
+                                    None
+                                }
+                            },
+                        ),
+                    )
+                })
+                .collect()
+        })
+    }
+
+    fn get_members_in_channel(&self, channel: ChannelId) -> Vec<Arc<CachedMember>> {
+        self.cache
+            .voice_channel_states(channel)
+            .map_or(Vec::new(), |vs| {
+                vs.iter()
+                    .map(|vs| self.cache.member(vs.guild_id.unwrap(), vs.user_id).unwrap())
+                    .filter(|m| !m.user.bot)
+                    .collect()
+            })
     }
 
     async fn batch<Fut, Out>(&self, futs: Vec<Fut>) -> Vec<Out>
@@ -506,54 +547,17 @@ impl Bot<'_> {
             .collect::<Vec<_>>();
 
         if !errors.is_empty() {
-            let channel = self.game.read().as_ref().map(|g| g.ctrl_channel);
-            if let Some(channel) = channel {
-                let _ = self
-                    .discord_http
-                    .create_message(channel)
-                    .content("errors occurred; check log")
-                    .unwrap()
-                    .await;
-            }
+            let _ = self
+                .discord_client
+                .create_message(self.broadcast_channel)
+                .content("Errors occurred during batch operation, check logs")
+                .unwrap()
+                .await;
             for error in errors {
-                error!("{}", error);
+                tracing::warn!("{}", error);
             }
         }
 
         successes.into_iter().map(TwiResult::unwrap).collect()
-    }
-
-    fn broadcast(&self) -> Option<CreateMessage<'_>> {
-        self.game
-            .read()
-            .as_ref()
-            .map(|g| self.discord_http.create_message(g.ctrl_channel))
-    }
-
-    fn get_members_in_channel(&self, voice_channel: &GuildChannel) -> Vec<Arc<CachedMember>> {
-        self.cache
-            .voice_channel_states(voice_channel.id())
-            .map_or(Vec::new(), |vs| {
-                vs.iter()
-                    .map(|vs| self.cache.member(vs.guild_id.unwrap(), vs.user_id).unwrap())
-                    .filter(|m| !m.user.bot && !m.roles.contains(&self.config.spectator_role))
-                    .collect()
-            })
-    }
-
-    fn is_game_in_progress(&self) -> bool {
-        self.game.read().is_some()
-    }
-
-    fn is_in_control(&self, user_id: UserId) -> bool {
-        matches!(self.owners.read().as_ref(), Some(owners) if owners.contains(&user_id))
-            || matches!(self.game.read().as_ref(), Some(game) if game.ctrl_user == user_id)
-    }
-
-    fn is_reacting_to_control(&self, reaction: &Reaction) -> bool {
-        matches!(
-            self.game.read().as_ref(),
-            Some(game) if game.ctrl_msg == reaction.message_id,
-        )
     }
 }

--- a/src/bot.rs
+++ b/src/bot.rs
@@ -350,10 +350,8 @@ impl Bot {
                     .partition::<Vec<_>, _>(|p| p.impostor);
 
                 imposters.is_empty() || imposters.len() >= crew.len()
-            } else if !matches!(state.as_ref(), Some(State::InGame { .. })) {
-                true
             } else {
-                false
+                !matches!(state.as_ref(), Some(State::InGame { .. }))
             }
         };
 

--- a/src/bot.rs
+++ b/src/bot.rs
@@ -53,7 +53,10 @@ impl Builder {
 
         let discord_gateway = Shard::new(
             &config.token,
-            Intents::GUILDS | Intents::GUILD_MESSAGES | Intents::GUILD_VOICE_STATES,
+            Intents::GUILDS
+                | Intents::GUILD_MEMBERS
+                | Intents::GUILD_MESSAGES
+                | Intents::GUILD_VOICE_STATES,
         );
 
         let (broadcast_channel, living_channel, dead_channel) = (
@@ -205,6 +208,8 @@ impl Bot {
         self.discord_gateway.start().await?;
 
         let event_flags: EventTypeFlags = EventTypeFlags::GUILD_CREATE
+            | EventTypeFlags::MESSAGE_CREATE
+            | EventTypeFlags::MEMBER_UPDATE
             | EventTypeFlags::MESSAGE_CREATE
             | EventTypeFlags::VOICE_STATE_UPDATE;
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -3,14 +3,14 @@ use crate::Result;
 use std::{fs::File, io::Read, path::Path};
 
 use serde::Deserialize;
-use twilight_model::id::{ChannelId, RoleId};
+use twilight_model::id::ChannelId;
 
 #[derive(Deserialize)]
 pub struct Config {
     pub token: String,
+    pub broadcast_channel: ChannelId,
     pub living_channel: ChannelId,
     pub dead_channel: ChannelId,
-    pub spectator_role: RoleId,
 }
 
 impl Config {

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,4 +1,0 @@
-#[allow(clippy::non_ascii_literal)]
-pub const EMER_EMOJI: &str = "🔴";
-#[allow(clippy::non_ascii_literal)]
-pub const DEAD_EMOJI: &str = "💀";

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,7 +13,7 @@ mod utils;
 
 use std::time::Duration;
 
-use crate::bot::Builder;
+use crate::bot::Bot;
 
 use sysinfo::{ProcessExt, RefreshKind, System, SystemExt};
 use taskinator_communicator::game::Game;
@@ -40,7 +40,7 @@ async fn bot_main() -> Result<()> {
     let (tx, rx) = watch::channel(None);
     let _au_watcher: JoinHandle<Result<()>> = tokio::spawn(async move {
         const CONN_RETRY_DELAY: u64 = 5;
-        const POLLING_DELAY: u64 = 3;
+        const POLLING_DELAY: u64 = 2;
         const MAX_CONSEC_FAILS: u64 = 3;
 
         let among_us_pid = {
@@ -115,7 +115,7 @@ async fn bot_main() -> Result<()> {
 
     // Setup bot
     tracing::info!("Constructing bot instance from config");
-    let mut bot = Builder::new("./Config.toml").build(rx).await?;
+    let mut bot = Bot::builder("./Config.toml").build(rx).await?;
 
     bot.start().await?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,74 +4,120 @@
     future_incompatible,
     nonstandard_style,
     rust_2018_idioms,
-    unused,
     warnings
 )]
 
 mod bot;
 mod config;
-mod constants;
+mod utils;
 
-use crate::bot::Bot;
+use std::time::Duration;
 
-use tokio_stream::StreamExt;
-use tracing::error;
-use twilight_model::gateway::event::Event;
+use crate::bot::Builder;
+
+use sysinfo::{ProcessExt, RefreshKind, System, SystemExt};
+use taskinator_communicator::game::Game;
+use tokio::{runtime, sync::watch, task::JoinHandle, time::sleep};
 
 type Result<T> = std::result::Result<T, Box<dyn std::error::Error + Send + Sync + 'static>>;
 
 fn main() -> Result<()> {
-    tokio::runtime::Runtime::new()
-        .unwrap()
+    runtime::Builder::new_multi_thread()
+        .worker_threads(4)
+        .thread_name("taskinator-worker")
+        .enable_all()
+        .build()?
         .block_on(async { bot_main().await })
 }
 
 async fn bot_main() -> Result<()> {
     // Setup
-    tracing_subscriber::fmt::init();
+    tracing_subscriber::fmt()
+        .with_env_filter("taskinator=info,taskinator_communicator=info,warn")
+        .init();
 
-    let mut bot = Bot::new("./Config.toml")?;
+    // Start Among Us watcher task
+    let (tx, rx) = watch::channel(None);
+    let _au_watcher: JoinHandle<Result<()>> = tokio::spawn(async move {
+        const CONN_RETRY_DELAY: u64 = 5;
+        const POLLING_DELAY: u64 = 3;
+        const MAX_CONSEC_FAILS: u64 = 3;
 
-    bot.fetch_app_details().await?;
+        let among_us_pid = {
+            let mut system = System::new_with_specifics(RefreshKind::new().with_processes());
 
-    // Start gateway
-    let mut events = bot.start_gateway().await?;
+            loop {
+                system.refresh_processes();
 
-    // Gateway event loop
-    while let Some(event) = events.next().await {
-        bot.update_cache(&event);
+                if let Some(among_us_proc) = system.get_process_by_name("Among Us.exe").first() {
+                    break among_us_proc.pid();
+                }
 
-        match event {
-            Event::MessageCreate(message) if !message.author.bot => {
-                let bot_clone = bot.clone();
-                tokio::spawn(async move {
-                    if let Err(e) = bot_clone.process_command(&message).await {
-                        error!(
-                            "Error processing command\nMessage: {:?}\nError: {}",
-                            &message, e
+                tracing::warn!("Could not find Among Us process... That's a bit sus.");
+                tracing::warn!("Will retry in {} seconds", CONN_RETRY_DELAY);
+
+                sleep(Duration::from_secs(CONN_RETRY_DELAY)).await;
+            }
+        };
+
+        tracing::info!("Among Us process found! PID: {}", among_us_pid);
+
+        let among_us = match Game::from_pid(among_us_pid) {
+            Ok(game) => game,
+            Err(why) => {
+                tracing::error!(
+                    "Opening a connection to the game failed, \
+                                make sure you have sufficient permissions"
+                );
+                return Err(why);
+            }
+        };
+
+        tracing::info!("Established connection to Among Us");
+
+        let mut failure_count = 0;
+        loop {
+            match among_us.state() {
+                Ok(state) => {
+                    tracing::debug!("Read updated state!");
+                    tracing::trace!("{:?}", state);
+                    failure_count = 0;
+                    tx.send(Some(state))?;
+                }
+                Err(why) => {
+                    if failure_count < MAX_CONSEC_FAILS {
+                        // If failure count has not reached max, increment but DO NOT update the
+                        // channel
+                        failure_count += 1;
+                        tracing::warn!(
+                            "An error occurred reading Among Us' state ({}/{}). \
+                            This can happen when the game is starting or changing level.",
+                            failure_count,
+                            MAX_CONSEC_FAILS,
                         );
+                        tracing::warn!("{}", why);
+                    } else {
+                        // At max failure count, log an error and set the channel to None to signal
+                        // no running game
+                        tracing::error!(
+                            "Failed to read Among Us' state again. \
+                            Retries exhausted, has the game closed?"
+                        );
+                        tracing::error!("{}", why);
+                        tx.send(None)?;
+                        return Err(why);
                     }
-                });
+                }
             }
-            Event::ReactionAdd(reaction) if reaction.user_id != bot.bot_id() => {
-                let bot_clone = bot.clone();
-                tokio::spawn(async move {
-                    if let Err(e) = bot_clone.reaction_add_handler(&reaction).await {
-                        error!("Error handling reaction add: {}", e);
-                    }
-                });
-            }
-            Event::ReactionRemove(reaction) if reaction.user_id != bot.bot_id() => {
-                let bot_clone = bot.clone();
-                tokio::spawn(async move {
-                    if let Err(e) = bot_clone.reaction_remove_handler(&reaction).await {
-                        error!("Error handling reaction remove: {}", e);
-                    }
-                });
-            }
-            _ => {}
+            sleep(Duration::from_secs(POLLING_DELAY)).await;
         }
-    }
+    });
+
+    // Setup bot
+    tracing::info!("Constructing bot instance from config");
+    let mut bot = Builder::new("./Config.toml").build(rx).await?;
+
+    bot.start().await?;
 
     Ok(())
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,38 @@
+use twilight_cache_inmemory::model::CachedMember;
+use twilight_http::{request::prelude::CreateMessage, Client};
+use twilight_model::channel::Message;
+
+use crate::Result;
+
+pub trait KnownAs {
+    fn known_as(&self) -> String;
+}
+
+impl KnownAs for CachedMember {
+    fn known_as(&self) -> String {
+        self.nick
+            .as_ref()
+            .map_or_else(|| self.user.name.to_owned(), ToOwned::to_owned)
+    }
+}
+
+pub trait ReplyTo {
+    fn reply<'a>(
+        &self,
+        client: &'a Client,
+        content: impl Into<String>,
+    ) -> Result<CreateMessage<'a>>;
+}
+
+impl ReplyTo for Message {
+    fn reply<'a>(
+        &self,
+        client: &'a Client,
+        content: impl Into<String>,
+    ) -> Result<CreateMessage<'a>> {
+        Ok(client
+            .create_message(self.channel_id)
+            .reply(self.id)
+            .content(content)?)
+    }
+}


### PR DESCRIPTION
The bot now reads Among Us' memory to determine which players are alive and dead and what the current state of the game is. It uses this information to determine which players should be muted, moved or able to speak at any given time. 

The bot must now be updated every time the game is updated.

The bot must be run by the host of the lobby or it will fail to detect the end of meetings.

Despite these limitations, this is a much smoother experience and is much preferred by the people I've play tested it with. Thanks again to @lewis-weinberger, @HJeffery, @EdanMiles and @CrumpetsOnToast for their help.